### PR TITLE
Fix Identify types to match

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,7 +40,7 @@ interface UserVars {
 
 interface FullStoryAPI {
   /**  https://help.fullstory.com/hc/en-us/articles/360020828113-FS-identify-Identifying-users */
-  (method: Identify, userId: string, vars?: UserVars): void;
+  (method: Identify, userId: string | false, vars?: UserVars): void;
 
   /**  https://help.fullstory.com/hc/en-us/articles/360020623314-FS-shutdown-and-FS-restart */
   (method: Shutdown): void;


### PR DESCRIPTION
The JS code matches as seen here:
https://github.com/mnsht/react-fullstory/blob/master/src/index.js#L24-L26

And the type is set correctly here:
https://github.com/mnsht/react-fullstory/blob/master/src/index.d.ts#L75
