### PR TITLE
feat: use CDN location for script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export default class FullStory extends React.Component {
       window['_fs_host'] = host || 'fullstory.com';
       window['_fs_org'] = org;
       window['_fs_namespace'] = namespace || 'FS';
+      window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
 
       includeFullStory();
     }
@@ -91,6 +92,7 @@ export default class FullStory extends React.Component {
     delete window['_fs_host'];
     delete window['_fs_org'];
     delete window['_fs_namespace'];
+    delete window['_fs_script'];
   }
 
   render() {


### PR DESCRIPTION
FullStory is now hosting the FullStory script (fs.js) on Google’s Content Delivery Network (CDN) and wants users to use that new location. More info: https://help.fullstory.com/hc/en-us/articles/360041242094